### PR TITLE
Add Ubuntu support, other enhancements

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,4 @@
 ---
 # handlers file for ansible-setup-globus-endpoint
+- name: update apt
+  apt: update_cache=yes

--- a/tasks/create_endpoint.yml
+++ b/tasks/create_endpoint.yml
@@ -56,10 +56,10 @@
   when: globus_user_name is not defined or globus_user_password is not defined
 
 # to ensure that we don't hang forever, set up a sleep / pkill subshell before we start the globus-connect-server-setup prcoess
-# TODO: investigate why this still runs even when the file referenced in "creates" is present
 - name: Setup server using globus-connect-server-setup
   shell: "(sleep 45 ; pkill -P $$) & globus-connect-server-setup"
-  creates: "/var/lib/globus-connect-server/gridftp.d/globus-connect-server-credential"
+  args:
+    creates: "/var/lib/globus-connect-server/gridftp.d/globus-connect-server-credential"
   environment:
     GLOBUS_USER: "{{ globus_user_name }}"
     GLOBUS_PASSWORD: "{{ globus_user_password }}"
@@ -67,5 +67,6 @@
   become: yes
 
 - debug:
-    var: STDOUT
+    msg: "Globus Connect server setup output was: {{ STDOUT }}"
+
 

--- a/tasks/create_endpoint.yml
+++ b/tasks/create_endpoint.yml
@@ -4,26 +4,68 @@
 # Get name from user
 # http://docs.ansible.com/ansible/latest/user_guide/playbooks_prompts.html
 
-- debug:
-    var: "{{ endpoint_name }}"
+# - debug:
+#     var: "{{ endpoint_name }}"
 
 # Edit config file
 # http://docs.ansible.com/ansible/latest/modules/lineinfile_module.html
 
-- lineinfile:
+- name: Set Globus User configuration
+  include_tasks: set_globus_config.yml
+  loop: "{{ globus_config_settings }} "
+  loop_control:
+    loop_var: config_section
+  vars:
+    globus_config_settings:
+      - section: Globus
+        settings:
+          - option: User
+            value: '%(GLOBUS_USER)s'
+          - option: Password
+            value: '%(GLOBUS_PASSWORD)s'
+      - section: Endpoint
+        settings:
+          - option: Name
+            value: '%(SHORT_HOSTNAME)s'
+          - option: Public
+            value: "{{ is_public|default('False') }}"
+      - section: GridFTP
+        settings:
+          - option: Server
+            value: '%(HOSTNAME)s'
+          - option: ServerBehindNAT
+            value: "{{ server_is_behind_nat|default('False') }}"
+      - section: MyProxy
+        settings:
+          - option: Server
+            value: '%(HOSTNAME)s'
+          - option: ServerBehindNAT
+            value: "{{ is_public|default('False') }}"
+    become: yes
+
+- name: Set DataInterface
+  ini_file:
     path: /etc/globus-connect-server.conf
-    regexp: "^Name ="
-    line: 'Name = {{ endpoint_name }}'
+    section: GridFTP
+    option: DataInterface
+    value: '{{ globus_datainterface_address }}'
+    state: present
+  when: server_is_behind_nat|default(False) != False
 
-- lineinfile:
-    path: /etc/globus-connect-server.conf
-    regexp: "^Public ="
-    line: 'Public = {{ is_public }}'
+- fail: msg="globus_user_name and globus_user_password variables are required to setup Globus Connect Server"
+  when: globus_user_name is not defined or globus_user_password is not defined
 
+# to ensure that we don't hang forever, set up a sleep / pkill subshell before we start the globus-connect-server-setup prcoess
+# TODO: investigate why this still runs even when the file referenced in "creates" is present
+- name: Setup server using globus-connect-server-setup
+  shell: "(sleep 45 ; pkill -P $$) & globus-connect-server-setup"
+  creates: "/var/lib/globus-connect-server/gridftp.d/globus-connect-server-credential"
+  environment:
+    GLOBUS_USER: "{{ globus_user_name }}"
+    GLOBUS_PASSWORD: "{{ globus_user_password }}"
+  register: STDOUT
+  become: yes
 
+- debug:
+    var: STDOUT
 
-
-#- name: Setup server
-#  command: globus-connect-server-setup
-#  use expect prompts
-#  http://docs.ansible.com/ansible/latest/modules/expect_module.html

--- a/tasks/install_globus_server.yml
+++ b/tasks/install_globus_server.yml
@@ -8,46 +8,81 @@
 - name: Add Globus key to local GPG keyring
   rpm_key:
     key: https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus
+  become: yes
+  when: ansible_os_family == "RedHat"
 
-- name: HTTP request Globus Connect Server RPM
+- name: Set RedHat/CentOS package source URL
+  set_fact:
+    globus_package_url: https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm
+  when: ansible_os_family == 'RedHat'
+
+- name: Set Debian/Ubuntu package source URL
+  set_fact:
+    globus_package_url: https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo_latest_all.deb
+  when: ansible_os_family == 'Debian'
+
+- name: HTTP request Globus Connect Server package
   get_url:
-    url: https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm
-    dest: "{{ playbook_dir }}"
+    url: "{{ globus_package_url }}"
+    dest: "{{ ansible_user_dir }}"
+
+- name: Install Globus Connect Server from .deb
+  apt: deb="{{ ansible_user_dir }}/globus-connect-server-repo_latest_all.deb"
+  notify: update apt
+  become: yes
+  when: ansible_os_family == 'Debian'
 
 # This RPM is not getting installed properly
 - name: Install Globus Connect RPM
   yum:
     name: globus-connect-server-repo-latest.noarch.rpm
   register: STDOUT
+  become: yes
+  when: ansible_os_family == 'RedHat'
+
 - debug:
     var: STDOUT
+  when: ansible_os_family == 'RedHat'
 
 - name: Request EPEL repository and download into local directory
   get_url:
     url: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     dest: "{{ playbook_dir }}"
+  become: yes  
+  when: ansible_os_family == 'RedHat'
 
 - name: Install EPEL
   yum:
     name: epel-release-latest-7.noarch.rpm
   register: STDOUT
+  become: yes
+  when: ansible_os_family == 'RedHat'
+
 - debug:
     var: STDOUT
+  when: ansible_os_family == 'RedHat'
 
 - name: Install Prerequisite packages
   yum:
     name: yum-plugin-priorities
     state: latest
   register: STDOUT
+  become: yes
+  when: ansible_os_family == 'RedHat'
+
 - debug:
     var: STDOUT
+  when: ansible_os_family == 'RedHat'
 
 # ERROR: No package or distribution found ...
 - name: Install Globus Connect Server
-  yum:
+  package:
     name: globus-connect-server
+    state: present
   register: STDOUT
-- debug:
-    var: STDOUT
+  become: yes
 
+- debug:
+    msg: STDOUT
+  when: ansible_os_family == 'RedHat'
 #?

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
 # tasks file for ansible-setup-globus-endpoint
 
+- name: install ntp
+  package: 
+    name: ntp 
+    state: present
+  become: yes
+
+- name: configure ntp service
+  service:
+    name: ntp
+    state: started
+    enabled: yes
+
 - name: Configure TCP ports for public access
   include_tasks: open_TCP_ports.yml
 
@@ -10,6 +22,6 @@
 - name: Create Endpoint
   include_tasks: create_endpoint.yml
 
-- name: Verify globus-gridftp-server Service
+- name: Ensure Globus Connect is started
   include_tasks: verify_service.yml
 

--- a/tasks/set_globus_config.yml
+++ b/tasks/set_globus_config.yml
@@ -1,0 +1,10 @@
+---
+- name: Set Globus User configuration, section {{ config_section.section }}
+  ini_file:
+    path: /etc/globus-connect-server.conf
+    section: "{{ config_section.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+    state: present
+  loop: "{{ config_section.settings }}"
+  become: yes

--- a/tasks/verify_service.yml
+++ b/tasks/verify_service.yml
@@ -1,8 +1,8 @@
 # Verify globus-gridftp-server Service
 
-#- name: test0
-#  command: ps aux | grep globus-gridftp-server
+- name: test0
+  shell: "ps aux | grep globus-gridftp-server"
 
-#- name: test1
-#  command: ps aux | grep myproxy-server
+- name: test1
+  shell: "ps aux | grep myproxy-server"
 


### PR DESCRIPTION
Hi @nathanShepherd - I haved used your Ansible role to set up a Globus Connect server at SANBI in South Africa. My server is running Ubuntu 18.04, so I had to make some changes. I also changed the setup of the configuration. To that end the `README.md` could be updated, as these variables are now used:

1. `endpoint_name`: string - endpoint name
2. `is_public`: True / False - is this a public endpoint
3. `server_is_behind_nat`: True / False - is the Globus Connect server behind a NAT gateway
4. `globus_datainterface_address`: string - hostname or IP address to use that is externally visible, necessary when `server_is_behind_nat` is True
5. `globus_user_name`: string - organisation's Globus ID
6. `globus_user_password`: string - organisation's Globus password

For the last two, I set up their collection in my server definition using `vars_prompt`. In part my host definition is:

---
- hosts: HOSTNAME
  vars:
  - endpoint_name: NAME
  - is_public: True
  - server_is_behind_nat: True
  - globus_datainterface_address: IPADDR
  vars_prompt:
    - name: globus_user_name
      prompt: "What is your organisation's Globus Connect username (i.e. Globus ID)?"
    - name: globus_user_password  
      prompt: "What is your organisation's Globus Connect password?"
  roles:
  - role: ansible-role-globus-server-setup
    tags: globus-server

I hope you find the PR useful.